### PR TITLE
Fix Unity - Builder link in builder.md

### DIFF
--- a/docs/github/builder.md
+++ b/docs/github/builder.md
@@ -2,7 +2,7 @@
 
 Building the project as part of a workflow may help to create mind-space and focus on the project itself.
 
-Use [Unity - Builder ](https://github.com/features/actions)
+Use [Unity - Builder ](https://github.com/marketplace/actions/unity-builder)
 to automatically build Unity projects for different platforms.
 
 ## Basic setup


### PR DESCRIPTION
The link used to point to https://github.com/features/actions.
This PR changes the link to https://github.com/marketplace/actions/unity-builder, so that it points to the actual page for the builder.

#### Changes

- Fixed a link that pointed to the wrong URL.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
